### PR TITLE
Default magic link tenant resolution to context domain

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -558,6 +558,17 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
         User user = new User();
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String tenantDomain = MultitenantUtils.getTenantDomain(username);
+        String contextTenantDomain = context.getTenantDomain();
+
+        if (StringUtils.isNotBlank(contextTenantDomain)) {
+            if (StringUtils.isNotBlank(tenantDomain) &&
+                    !StringUtils.equalsIgnoreCase(contextTenantDomain, tenantDomain) && log.isDebugEnabled()) {
+                log.debug(String.format(
+                        "User tenant domain: %s does not match context tenant domain: %s. Proceeding with the " +
+                                "context tenant domain.", tenantDomain, contextTenantDomain));
+            }
+            tenantDomain = contextTenantDomain;
+        }
 
         user.setUsername(tenantAwareUsername);
         user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(username));

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
@@ -554,6 +554,22 @@ public class MagicLinkAuthenticatorTest {
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
     }
 
+    @Test(description = "Test case for resolveUser() when tenant domains mismatch")
+    public void testResolveUserDefaultsToContextTenantDomain() throws Exception {
+
+        when(httpServletRequest.getParameter(MagicLinkAuthenticatorConstants.USER_NAME)).thenReturn(USERNAME);
+        when(FrameworkUtils.preprocessUsername(USERNAME, context)).thenReturn(USERNAME_WITH_TENANT_DOMAIN);
+        when(MultitenantUtils.getTenantAwareUsername(USERNAME_WITH_TENANT_DOMAIN)).thenReturn(USERNAME);
+        when(MultitenantUtils.getTenantDomain(USERNAME_WITH_TENANT_DOMAIN)).thenReturn("wso2.com");
+        when(IdentityUtil.isEmailUsernameValidationDisabled()).thenReturn(true);
+        mockStatic(UserCoreUtil.class);
+        when(UserCoreUtil.extractDomainFromName(USERNAME_WITH_TENANT_DOMAIN)).thenReturn(USER_STORE_DOMAIN);
+        context.setTenantDomain(SUPER_TENANT_DOMAIN);
+
+        User resolvedUser = Whitebox.invokeMethod(magicLinkAuthenticator, "resolveUser", httpServletRequest, context);
+        Assert.assertEquals(resolvedUser.getTenantDomain(), SUPER_TENANT_DOMAIN);
+    }
+
     @ObjectFactory
     public IObjectFactory getObjectFactory() {
 


### PR DESCRIPTION
## Summary
- ensure magic link user resolution defaults to the authentication context tenant domain without erroring on mismatches
- add a unit test that verifies tenant mismatches resolve to the context tenant domain
- remove the unused tenant-domain-mismatch error constant introduced in the previous iteration

## Testing
- mvn -pl components/org.wso2.carbon.identity.application.authenticator.magiclink test *(fails: parent POM org.wso2:wso2:1.4 cannot be downloaded from Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b836afa88323971343d7b665c015